### PR TITLE
Add repository AGENTS guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,43 @@
+# Root AGENTS
+
+This repository contains the **Trick Simulation Environment**.  Contributors should consult this file and any nested `AGENTS.md` files before making changes.
+
+## Index of Agents
+- `/AGENTS.md` (this file): repository wide guidelines.
+- `/docs/AGENTS.md`: rules for documentation within `docs/`.
+- `/trick_source/AGENTS.md`: rules for C/C++ source under `trick_source/`.
+- `/share/trick/pymods/trick/AGENTS.md`: rules for Python modules under `share/trick/pymods/trick/`.
+
+These nested files extend the instructions here.  When editing a file, follow the instructions for the most specific `AGENTS.md` in its path.
+
+## General Style
+- Use **four spaces** for indentation.
+- Keep lines under **120 characters** when practical.
+- Include a license header when creating new source files (see existing files for examples).
+- Commit messages should follow the pattern:
+  ```
+  Short summary (50 chars or less)
+
+  More detailed explanation of the change.
+  ```
+
+## Building and Testing
+- After modifying C/C++ or Python code run `make test` from the repository root.  This builds the project and executes the test suite.
+- Python modules in `share/trick/pymods/trick` contain additional tests that can be run with `python run_tests.py` from that directory.
+- If the environment prevents the tests from running, note this in your pull request.
+- Documentation only changes do not require running the full test suite but should be spell checked.
+
+## Repository Overview
+```
+CMakeModules/    - CMake build helpers
+CMakeTestFiles/  - Example CMake projects
+autoconf/        - Autotools scripts
+bin/             - command line utilities (Perl, shell)
+docs/            - user and developer documentation
+include/         - public header files
+libexec/         - build and maintenance scripts
+share/           - configuration files, python modules, templates
+trick_source/    - core Trick libraries (C/C++)
+trick_sims/      - example simulations
+test/            - unit and integration tests
+```

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,42 @@
+# Documentation Agent
+
+This file governs all documentation under `docs/` including `developer_docs`, `documentation`, `howto_guides`, and related assets.
+
+## Scope
+Any Markdown (`.md`) or documentation specific configuration inside this directory tree follows these rules.
+
+### Directory Outline
+```
+developer_docs/    - Internal developer information
+howto_guides/      - Step by step guides for users
+documentation/     - Main user documentation
+_layouts/          - Jekyll layouts for the website
+```
+
+## Style Guidelines
+- Use GitHub Flavored Markdown.
+- Begin each document with a top level `# Title` followed by a short introductory paragraph.
+- Wrap lines at 120 characters or less for readability.
+- Use relative links when referring to other files in this repository.
+- Prefer fenced code blocks with language hints: <code>```python</code>, <code>```cpp</code>, etc.
+
+### Template
+Use the following skeleton for new documents:
+```markdown
+# Title
+
+Short summary of the page purpose.
+
+## Overview
+Describe the workflow or concept.
+
+## References
+- [Related Document](../path/to/doc.md)
+```
+
+## Verification Questions
+1. Does the new documentation follow the heading and line length conventions?
+2. Are cross references written with relative paths?
+3. Is the writing concise and free of obvious grammar issues?
+4. Are code blocks properly fenced with language identifiers?
+5. Have spelling and formatting been checked before commit?

--- a/share/trick/pymods/trick/AGENTS.md
+++ b/share/trick/pymods/trick/AGENTS.md
@@ -1,0 +1,46 @@
+# Python Modules Agent
+
+Guidelines for Python code under `share/trick/pymods/trick`.
+
+## Scope
+This directory contains Python helpers and tests for Trick.
+
+### Key Files
+```
+utils.py           - helper utilities
+variable_server.py - variable server client
+run_tests.py       - script to run pytest
+tests/             - pytest based tests
+```
+
+## Style Guidelines
+- Follow [PEP8](https://peps.python.org/pep-0008/).
+- Use 4 spaces per indentation level.
+- Include module level docstrings and descriptive comments.
+- Prefer explicit is better than implicit.
+
+### Template
+```python
+"""Short module description."""
+
+class Example:
+    def __init__(self):
+        pass
+
+def main():
+    pass
+
+if __name__ == "__main__":
+    main()
+```
+
+## Common Actions
+- Install dependencies: `pip install -r requirements.txt`.
+- Run tests with `python run_tests.py`.
+
+## Verification Questions
+1. Does the code comply with PEP8 (indentation, naming)?
+2. Are new features covered by tests in `tests/`?
+3. Was `python run_tests.py` executed before committing?
+4. Are docstrings provided for public classes and functions?
+5. Are imports sorted and unused imports removed?

--- a/trick_source/AGENTS.md
+++ b/trick_source/AGENTS.md
@@ -1,0 +1,52 @@
+# Trick Source Agent
+
+Rules in this file apply to all C and C++ code inside `trick_source/`.
+
+## Scope
+```
+codegen/       - Code generation tools
+sim_services/  - Core simulation services
+trick_utils/   - Utility libraries
+trick_swig/    - SWIG interfaces
+web/           - Web server and dashboard
+```
+
+## Coding Style
+- Indent with **4 spaces**.
+- Place opening braces on the same line as control statements and function definitions.
+- Use C++ style comments `//` or block comments `/* */` as in existing files.
+- Prefer standard library containers and algorithms when possible.
+- Keep functions short and focused.
+
+### Template
+Header (`.hh`):
+```cpp
+#ifndef MY_CLASS_HH
+#define MY_CLASS_HH
+
+class MyClass {
+public:
+    MyClass();
+    ~MyClass();
+};
+
+#endif
+```
+Source (`.cpp`):
+```cpp
+#include "MyClass.hh"
+
+MyClass::MyClass() {}
+MyClass::~MyClass() {}
+```
+
+## Common Actions
+- Build and run the test suite with `make test` from the repository root.
+- Unit tests may exist under each component's `test` directory and are built through their Makefiles.
+
+## Verification Questions
+1. Does new code follow the 4-space indentation and brace placement rules?
+2. Are header include guards present and unique?
+3. Are unit tests or regression tests updated when functionality changes?
+4. Was `make test` executed after the changes?
+5. Do commit messages reference relevant issue numbers when applicable?


### PR DESCRIPTION
## Summary
- add root AGENTS file describing repo structure and how to test
- add documentation guidelines
- add C/C++ coding guidelines for Trick source
- add Python module guidelines

## Testing
- `make test` *(fails: Please run /workspace/trick/configure before running make test)*
- `python run_tests.py` *(fails: ModuleNotFoundError: No module named 'psutil')*


------
https://chatgpt.com/codex/tasks/task_e_6843138066748322988752e8532fb704